### PR TITLE
Sigsegv, adress->ifa_addr can be a null pointer

### DIFF
--- a/chap01/unix_list.c
+++ b/chap01/unix_list.c
@@ -40,6 +40,10 @@ int main() {
 
     struct ifaddrs *address = addresses;
     while(address) {
+        if (address->ifa_addr == NULL) { 
+            address = address->ifa_next;
+            continue;
+        }
         int family = address->ifa_addr->sa_family;
         if (family == AF_INET || family == AF_INET6) {
 


### PR DESCRIPTION
I get SIGSEGV when try to execute it (ubuntu 16.04, gcc 5.4.0). According to http://man7.org/linux/man-pages/man3/getifaddrs.3.html : 

> The ifa_addr field points to a structure containing the interface
       address.  (The sa_family subfield should be consulted to determine
       the format of the address structure.)  **This field may contain a null
       pointer**.

Little check for null pointer proposed. Or may be it'll be better with for cycle since two lines of adress = adress->ifa_addr in my proposal.