### PR TITLE
added #define _GNU_SOURCE

### DIFF
--- a/chap01/unix_list.c
+++ b/chap01/unix_list.c
@@ -21,6 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+#define _GNU_SOURCE
 
 #include <sys/socket.h>
 #include <netdb.h>


### PR DESCRIPTION
#define _GNU_SOURCE is required to access nonstandard GNU/Linux extension functions. Code won't compile without it and show errors.