### PR TITLE
Use perror() in case getifaddrs() call fails

### DIFF
--- a/chap01/unix_list.c
+++ b/chap01/unix_list.c
@@ -34,7 +34,7 @@ int main() {
     struct ifaddrs *addresses;
 
     if (getifaddrs(&addresses) == -1) {
-        printf("getifaddrs call failed\n");
+        perror("getifaddrs call failed");
         return -1;
     }
 


### PR DESCRIPTION
According to https://man7.org/linux/man-pages/man3/getifaddrs.3.html getifaddrs() returns -1 on error and sets errno. Use the perror() function to provide a more informative error message in such cases.