### PR TITLE
Check result of getaddrinfo() calls consistently

### DIFF
--- a/chap02/time_server.c
+++ b/chap02/time_server.c
@@ -80,7 +80,11 @@ int main() {
     hints.ai_flags = AI_PASSIVE;
 
     struct addrinfo *bind_address;
-    getaddrinfo(0, "8080", &hints, &bind_address);
+    int getaddrinfo_result = getaddrinfo(0, "8080", &hints, &bind_address);
+    if (getaddrinfo_result) {
+        fprintf(stderr, "getaddrinfo() failed. (%d, %d)\n", getaddrinfo_result, GETSOCKETERRNO());
+        return 1;
+    }
 
 
     printf("Creating socket...\n");

--- a/chap02/time_server_dual.c
+++ b/chap02/time_server_dual.c
@@ -84,7 +84,11 @@ int main() {
     hints.ai_flags = AI_PASSIVE;
 
     struct addrinfo *bind_address;
-    getaddrinfo(0, "8080", &hints, &bind_address);
+    int getaddrinfo_result = getaddrinfo(0, "8080", &hints, &bind_address);
+    if (getaddrinfo_result) {
+        fprintf(stderr, "getaddrinfo() failed. (%d, %d)\n", getaddrinfo_result, GETSOCKETERRNO());
+        return 1;
+    }
 
 
     printf("Creating socket...\n");

--- a/chap02/time_server_ipv6.c
+++ b/chap02/time_server_ipv6.c
@@ -80,7 +80,11 @@ int main() {
     hints.ai_flags = AI_PASSIVE;
 
     struct addrinfo *bind_address;
-    getaddrinfo(0, "8080", &hints, &bind_address);
+    int getaddrinfo_result = getaddrinfo(0, "8080", &hints, &bind_address);
+    if (getaddrinfo_result) {
+        fprintf(stderr, "getaddrinfo() failed. (%d, %d)\n", getaddrinfo_result, GETSOCKETERRNO());
+        return 1;
+    }
 
 
     printf("Creating socket...\n");

--- a/chap03/tcp_client.c
+++ b/chap03/tcp_client.c
@@ -48,8 +48,9 @@ int main(int argc, char *argv[]) {
     memset(&hints, 0, sizeof(hints));
     hints.ai_socktype = SOCK_STREAM;
     struct addrinfo *peer_address;
-    if (getaddrinfo(argv[1], argv[2], &hints, &peer_address)) {
-        fprintf(stderr, "getaddrinfo() failed. (%d)\n", GETSOCKETERRNO());
+    int getaddrinfo_result = getaddrinfo(argv[1], argv[2], &hints, &peer_address);
+    if (getaddrinfo_result) {
+        fprintf(stderr, "getaddrinfo() failed. (%d, %d)\n", getaddrinfo_result, GETSOCKETERRNO());
         return 1;
     }
 

--- a/chap03/tcp_serve_chat.c
+++ b/chap03/tcp_serve_chat.c
@@ -44,7 +44,11 @@ int main() {
     hints.ai_flags = AI_PASSIVE;
 
     struct addrinfo *bind_address;
-    getaddrinfo(0, "8080", &hints, &bind_address);
+    int getaddrinfo_result = getaddrinfo(0, "8080", &hints, &bind_address);
+    if (getaddrinfo_result) {
+        fprintf(stderr, "getaddrinfo() failed. (%d, %d)\n", getaddrinfo_result, GETSOCKETERRNO());
+        return 1;
+    }
 
 
     printf("Creating socket...\n");

--- a/chap03/tcp_serve_toupper.c
+++ b/chap03/tcp_serve_toupper.c
@@ -44,7 +44,11 @@ int main() {
     hints.ai_flags = AI_PASSIVE;
 
     struct addrinfo *bind_address;
-    getaddrinfo(0, "8080", &hints, &bind_address);
+    int getaddrinfo_result = getaddrinfo(0, "8080", &hints, &bind_address);
+    if (getaddrinfo_result) {
+        fprintf(stderr, "getaddrinfo() failed. (%d, %d)\n", getaddrinfo_result, GETSOCKETERRNO());
+        return 1;
+    }
 
 
     printf("Creating socket...\n");

--- a/chap03/tcp_serve_toupper_fork.c
+++ b/chap03/tcp_serve_toupper_fork.c
@@ -41,7 +41,11 @@ int main() {
     hints.ai_flags = AI_PASSIVE;
 
     struct addrinfo *bind_address;
-    getaddrinfo(0, "8080", &hints, &bind_address);
+    int getaddrinfo_result = getaddrinfo(0, "8080", &hints, &bind_address);
+    if (getaddrinfo_result) {
+        fprintf(stderr, "getaddrinfo() failed. (%d, %d)\n", getaddrinfo_result, GETSOCKETERRNO());
+        return 1;
+    }
 
 
     printf("Creating socket...\n");

--- a/chap04/udp_client.c
+++ b/chap04/udp_client.c
@@ -48,8 +48,9 @@ int main(int argc, char *argv[]) {
     memset(&hints, 0, sizeof(hints));
     hints.ai_socktype = SOCK_DGRAM;
     struct addrinfo *peer_address;
-    if (getaddrinfo(argv[1], argv[2], &hints, &peer_address)) {
-        fprintf(stderr, "getaddrinfo() failed. (%d)\n", GETSOCKETERRNO());
+    int getaddrinfo_result = getaddrinfo(argv[1], argv[2], &hints, &peer_address);
+    if (getaddrinfo_result) {
+        fprintf(stderr, "getaddrinfo() failed. (%d, %d)\n", getaddrinfo_result, GETSOCKETERRNO());
         return 1;
     }
 

--- a/chap04/udp_recvfrom.c
+++ b/chap04/udp_recvfrom.c
@@ -42,7 +42,11 @@ int main() {
     hints.ai_flags = AI_PASSIVE;
 
     struct addrinfo *bind_address;
-    getaddrinfo(0, "8080", &hints, &bind_address);
+    int getaddrinfo_result = getaddrinfo(0, "8080", &hints, &bind_address);
+    if (getaddrinfo_result) {
+        fprintf(stderr, "getaddrinfo() failed. (%d, %d)\n", getaddrinfo_result, GETSOCKETERRNO());
+        return 1;
+    }
 
 
     printf("Creating socket...\n");

--- a/chap04/udp_sendto.c
+++ b/chap04/udp_sendto.c
@@ -39,8 +39,9 @@ int main() {
     memset(&hints, 0, sizeof(hints));
     hints.ai_socktype = SOCK_DGRAM;
     struct addrinfo *peer_address;
-    if (getaddrinfo("127.0.0.1", "8080", &hints, &peer_address)) {
-        fprintf(stderr, "getaddrinfo() failed. (%d)\n", GETSOCKETERRNO());
+    int getaddrinfo_result = getaddrinfo("127.0.0.1", "8080", &hints, &peer_address);
+    if (getaddrinfo_result) {
+        fprintf(stderr, "getaddrinfo() failed. (%d, %d)\n", getaddrinfo_result, GETSOCKETERRNO());
         return 1;
     }
 

--- a/chap04/udp_serve_toupper.c
+++ b/chap04/udp_serve_toupper.c
@@ -44,7 +44,11 @@ int main() {
     hints.ai_flags = AI_PASSIVE;
 
     struct addrinfo *bind_address;
-    getaddrinfo(0, "8080", &hints, &bind_address);
+    int getaddrinfo_result = getaddrinfo(0, "8080", &hints, &bind_address);
+    if (getaddrinfo_result) {
+        fprintf(stderr, "getaddrinfo() failed. (%d, %d)\n", getaddrinfo_result, GETSOCKETERRNO());
+        return 1;
+    }
 
 
     printf("Creating socket...\n");

--- a/chap04/udp_serve_toupper_simple.c
+++ b/chap04/udp_serve_toupper_simple.c
@@ -44,7 +44,11 @@ int main() {
     hints.ai_flags = AI_PASSIVE;
 
     struct addrinfo *bind_address;
-    getaddrinfo(0, "8080", &hints, &bind_address);
+    int getaddrinfo_result = getaddrinfo(0, "8080", &hints, &bind_address);
+    if (getaddrinfo_result) {
+        fprintf(stderr, "getaddrinfo() failed. (%d, %d)\n", getaddrinfo_result, GETSOCKETERRNO());
+        return 1;
+    }
 
 
     printf("Creating socket...\n");

--- a/chap05/dns_query.c
+++ b/chap05/dns_query.c
@@ -269,8 +269,9 @@ int main(int argc, char *argv[]) {
     memset(&hints, 0, sizeof(hints));
     hints.ai_socktype = SOCK_DGRAM;
     struct addrinfo *peer_address;
-    if (getaddrinfo("8.8.8.8", "53", &hints, &peer_address)) {
-        fprintf(stderr, "getaddrinfo() failed. (%d)\n", GETSOCKETERRNO());
+    int getaddrinfo_result = getaddrinfo("8.8.8.8", "53", &hints, &peer_address);
+    if (getaddrinfo_result) {
+        fprintf(stderr, "getaddrinfo() failed. (%d, %d)\n", getaddrinfo_result, GETSOCKETERRNO());
         return 1;
     }
 

--- a/chap05/lookup.c
+++ b/chap05/lookup.c
@@ -49,8 +49,9 @@ int main(int argc, char *argv[]) {
     memset(&hints, 0, sizeof(hints));
     hints.ai_flags = AI_ALL;
     struct addrinfo *peer_address;
-    if (getaddrinfo(argv[1], 0, &hints, &peer_address)) {
-        fprintf(stderr, "getaddrinfo() failed. (%d)\n", GETSOCKETERRNO());
+    int getaddrinfo_result = getaddrinfo(argv[1], 0, &hints, &peer_address);
+    if (getaddrinfo_result) {
+        fprintf(stderr, "getaddrinfo() failed. (%d, %d)\n", getaddrinfo_result, GETSOCKETERRNO());
         return 1;
     }
 

--- a/chap06/web_get.c
+++ b/chap06/web_get.c
@@ -96,8 +96,9 @@ SOCKET connect_to_host(char *hostname, char *port) {
     memset(&hints, 0, sizeof(hints));
     hints.ai_socktype = SOCK_STREAM;
     struct addrinfo *peer_address;
-    if (getaddrinfo(hostname, port, &hints, &peer_address)) {
-        fprintf(stderr, "getaddrinfo() failed. (%d)\n", GETSOCKETERRNO());
+    int getaddrinfo_result = getaddrinfo(hostname, port, &hints, &peer_address);
+    if (getaddrinfo_result) {
+        fprintf(stderr, "getaddrinfo() failed. (%d, %d)\n", getaddrinfo_result, GETSOCKETERRNO());
         exit(1);
     }
 

--- a/chap07/web_server.c
+++ b/chap07/web_server.c
@@ -57,7 +57,11 @@ SOCKET create_socket(const char* host, const char *port) {
     hints.ai_flags = AI_PASSIVE;
 
     struct addrinfo *bind_address;
-    getaddrinfo(host, port, &hints, &bind_address);
+    int getaddrinfo_result = getaddrinfo(host, port, &hints, &bind_address);
+    if (getaddrinfo_result) {
+        fprintf(stderr, "getaddrinfo() failed. (%d, %d)\n", getaddrinfo_result, GETSOCKETERRNO());
+        exit(1);
+    }
 
     printf("Creating socket...\n");
     SOCKET socket_listen;

--- a/chap07/web_server2.c
+++ b/chap07/web_server2.c
@@ -57,7 +57,11 @@ SOCKET create_socket(const char* host, const char *port) {
     hints.ai_flags = AI_PASSIVE;
 
     struct addrinfo *bind_address;
-    getaddrinfo(host, port, &hints, &bind_address);
+    int getaddrinfo_result = getaddrinfo(host, port, &hints, &bind_address);
+    if (getaddrinfo_result) {
+        fprintf(stderr, "getaddrinfo() failed. (%d, %d)\n", getaddrinfo_result, GETSOCKETERRNO());
+        exit(1);
+    }
 
     printf("Creating socket...\n");
     SOCKET socket_listen;

--- a/chap08/smtp_send.c
+++ b/chap08/smtp_send.c
@@ -117,8 +117,9 @@ SOCKET connect_to_host(const char *hostname, const char *port) {
     memset(&hints, 0, sizeof(hints));
     hints.ai_socktype = SOCK_STREAM;
     struct addrinfo *peer_address;
-    if (getaddrinfo(hostname, port, &hints, &peer_address)) {
-        fprintf(stderr, "getaddrinfo() failed. (%d)\n", GETSOCKETERRNO());
+    int getaddrinfo_result = getaddrinfo(hostname, port, &hints, &peer_address);
+    if (getaddrinfo_result) {
+        fprintf(stderr, "getaddrinfo() failed. (%d, %d)\n", getaddrinfo_result, GETSOCKETERRNO());
         exit(1);
     }
 

--- a/chap09/https_get.c
+++ b/chap09/https_get.c
@@ -95,8 +95,9 @@ SOCKET connect_to_host(char *hostname, char *port) {
     memset(&hints, 0, sizeof(hints));
     hints.ai_socktype = SOCK_STREAM;
     struct addrinfo *peer_address;
-    if (getaddrinfo(hostname, port, &hints, &peer_address)) {
-        fprintf(stderr, "getaddrinfo() failed. (%d)\n", GETSOCKETERRNO());
+    int getaddrinfo_result = getaddrinfo(hostname, port, &hints, &peer_address);
+    if (getaddrinfo_result) {
+        fprintf(stderr, "getaddrinfo() failed. (%d, %d)\n", getaddrinfo_result, GETSOCKETERRNO());
         exit(1);
     }
 

--- a/chap09/https_simple.c
+++ b/chap09/https_simple.c
@@ -59,9 +59,10 @@ int main(int argc, char *argv[]) {
     memset(&hints, 0, sizeof(hints));
     hints.ai_socktype = SOCK_STREAM;
     struct addrinfo *peer_address;
-    if (getaddrinfo(hostname, port, &hints, &peer_address)) {
-        fprintf(stderr, "getaddrinfo() failed. (%d)\n", GETSOCKETERRNO());
-        exit(1);
+    int getaddrinfo_result = getaddrinfo(hostname, port, &hints, &peer_address);
+    if (getaddrinfo_result) {
+        fprintf(stderr, "getaddrinfo() failed. (%d, %d)\n", getaddrinfo_result, GETSOCKETERRNO());
+        return 1;
     }
 
     printf("Remote address is: ");

--- a/chap09/tls_client.c
+++ b/chap09/tls_client.c
@@ -59,8 +59,9 @@ int main(int argc, char *argv[]) {
     memset(&hints, 0, sizeof(hints));
     hints.ai_socktype = SOCK_STREAM;
     struct addrinfo *peer_address;
-    if (getaddrinfo(argv[1], argv[2], &hints, &peer_address)) {
-        fprintf(stderr, "getaddrinfo() failed. (%d)\n", GETSOCKETERRNO());
+    int getaddrinfo_result = getaddrinfo(argv[1], argv[2], &hints, &peer_address);
+    if (getaddrinfo_result) {
+        fprintf(stderr, "getaddrinfo() failed. (%d, %d)\n", getaddrinfo_result, GETSOCKETERRNO());
         return 1;
     }
 

--- a/chap09/tls_get_cert.c
+++ b/chap09/tls_get_cert.c
@@ -59,9 +59,10 @@ int main(int argc, char *argv[]) {
     memset(&hints, 0, sizeof(hints));
     hints.ai_socktype = SOCK_STREAM;
     struct addrinfo *peer_address;
-    if (getaddrinfo(hostname, port, &hints, &peer_address)) {
-        fprintf(stderr, "getaddrinfo() failed. (%d)\n", GETSOCKETERRNO());
-        exit(1);
+    int getaddrinfo_result = getaddrinfo(hostname, port, &hints, &peer_address);
+    if (getaddrinfo_result) {
+        fprintf(stderr, "getaddrinfo() failed. (%d, %d)\n", getaddrinfo_result, GETSOCKETERRNO());
+        return 1;
     }
 
     printf("Remote address is: ");

--- a/chap10/https_server.c
+++ b/chap10/https_server.c
@@ -57,7 +57,11 @@ SOCKET create_socket(const char* host, const char *port) {
     hints.ai_flags = AI_PASSIVE;
 
     struct addrinfo *bind_address;
-    getaddrinfo(host, port, &hints, &bind_address);
+    int getaddrinfo_result = getaddrinfo(host, port, &hints, &bind_address);
+    if (getaddrinfo_result) {
+        fprintf(stderr, "getaddrinfo() failed. (%d, %d)\n", getaddrinfo_result, GETSOCKETERRNO());
+        exit(1);
+    }
 
     printf("Creating socket...\n");
     SOCKET socket_listen;

--- a/chap10/tls_time_server.c
+++ b/chap10/tls_time_server.c
@@ -63,7 +63,11 @@ int main() {
     hints.ai_flags = AI_PASSIVE;
 
     struct addrinfo *bind_address;
-    getaddrinfo(0, "8080", &hints, &bind_address);
+    int getaddrinfo_result = getaddrinfo(0, "8080", &hints, &bind_address);
+    if (getaddrinfo_result) {
+        fprintf(stderr, "getaddrinfo() failed. (%d, %d)\n", getaddrinfo_result, GETSOCKETERRNO());
+        return 1;
+    }
 
 
     printf("Creating socket...\n");

--- a/chap13/big_send.c
+++ b/chap13/big_send.c
@@ -44,8 +44,9 @@ int main(int argc, char *argv[]) {
     memset(&hints, 0, sizeof(hints));
     hints.ai_socktype = SOCK_STREAM;
     struct addrinfo *peer_address;
-    if (getaddrinfo(argv[1], argv[2], &hints, &peer_address)) {
-        fprintf(stderr, "getaddrinfo() failed. (%d)\n", GETSOCKETERRNO());
+    int getaddrinfo_result = getaddrinfo(argv[1], argv[2], &hints, &peer_address);
+    if (getaddrinfo_result) {
+        fprintf(stderr, "getaddrinfo() failed. (%d, %d)\n", getaddrinfo_result, GETSOCKETERRNO());
         return 1;
     }
 

--- a/chap13/connect_blocking.c
+++ b/chap13/connect_blocking.c
@@ -44,8 +44,9 @@ int main(int argc, char *argv[]) {
     memset(&hints, 0, sizeof(hints));
     hints.ai_socktype = SOCK_STREAM;
     struct addrinfo *peer_address;
-    if (getaddrinfo(argv[1], argv[2], &hints, &peer_address)) {
-        fprintf(stderr, "getaddrinfo() failed. (%d)\n", GETSOCKETERRNO());
+    int getaddrinfo_result = getaddrinfo(argv[1], argv[2], &hints, &peer_address);
+    if (getaddrinfo_result) {
+        fprintf(stderr, "getaddrinfo() failed. (%d, %d)\n", getaddrinfo_result, GETSOCKETERRNO());
         return 1;
     }
 

--- a/chap13/connect_timeout.c
+++ b/chap13/connect_timeout.c
@@ -50,8 +50,9 @@ int main(int argc, char *argv[]) {
     memset(&hints, 0, sizeof(hints));
     hints.ai_socktype = SOCK_STREAM;
     struct addrinfo *peer_address;
-    if (getaddrinfo(argv[1], argv[2], &hints, &peer_address)) {
-        fprintf(stderr, "getaddrinfo() failed. (%d)\n", GETSOCKETERRNO());
+    int getaddrinfo_result = getaddrinfo(argv[1], argv[2], &hints, &peer_address);
+    if (getaddrinfo_result) {
+        fprintf(stderr, "getaddrinfo() failed. (%d, %d)\n", getaddrinfo_result, GETSOCKETERRNO());
         return 1;
     }
 

--- a/chap13/server_crash.c
+++ b/chap13/server_crash.c
@@ -47,7 +47,11 @@ int main() {
     hints.ai_flags = AI_PASSIVE;
 
     struct addrinfo *bind_address;
-    getaddrinfo(0, "8080", &hints, &bind_address);
+    int getaddrinfo_result = getaddrinfo(0, "8080", &hints, &bind_address);
+    if (getaddrinfo_result) {
+        fprintf(stderr, "getaddrinfo() failed. (%d, %d)\n", getaddrinfo_result, GETSOCKETERRNO());
+        return 1;
+    }
 
 
     printf("Creating socket...\n");

--- a/chap13/server_ignore.c
+++ b/chap13/server_ignore.c
@@ -42,7 +42,11 @@ int main() {
     hints.ai_flags = AI_PASSIVE;
 
     struct addrinfo *bind_address;
-    getaddrinfo(0, "8080", &hints, &bind_address);
+    int getaddrinfo_result = getaddrinfo(0, "8080", &hints, &bind_address);
+    if (getaddrinfo_result) {
+        fprintf(stderr, "getaddrinfo() failed. (%d, %d)\n", getaddrinfo_result, GETSOCKETERRNO());
+        return 1;
+    }
 
 
     printf("Creating socket...\n");

--- a/chap13/server_noreuse.c
+++ b/chap13/server_noreuse.c
@@ -42,7 +42,11 @@ int main() {
     hints.ai_flags = AI_PASSIVE;
 
     struct addrinfo *bind_address;
-    getaddrinfo(0, "8080", &hints, &bind_address);
+    int getaddrinfo_result = getaddrinfo(0, "8080", &hints, &bind_address);
+    if (getaddrinfo_result) {
+        fprintf(stderr, "getaddrinfo() failed. (%d, %d)\n", getaddrinfo_result, GETSOCKETERRNO());
+        return 1;
+    }
 
 
     printf("Creating socket...\n");

--- a/chap13/server_reuse.c
+++ b/chap13/server_reuse.c
@@ -42,7 +42,11 @@ int main() {
     hints.ai_flags = AI_PASSIVE;
 
     struct addrinfo *bind_address;
-    getaddrinfo(0, "8080", &hints, &bind_address);
+    int getaddrinfo_result = getaddrinfo(0, "8080", &hints, &bind_address);
+    if (getaddrinfo_result) {
+        fprintf(stderr, "getaddrinfo() failed. (%d, %d)\n", getaddrinfo_result, GETSOCKETERRNO());
+        return 1;
+    }
 
 
     printf("Creating socket...\n");


### PR DESCRIPTION
The getaddrinfo() function returns 0 on success or a non-zero error code on failure. For reference:
- https://man7.org/linux/man-pages/man3/getaddrinfo.3.html
- https://learn.microsoft.com/en-us/windows/win32/api/ws2tcpip/nf-ws2tcpip-getaddrinfo

On Unix systems, errno is only set in the case where the return code is EAI_SYSTEM, therefore showing the errno code in all other cases would not provide meaningful information.

Print the return code of the function call along with errno to provide all the information needed to determine the cause of the error.

Add checks for the return code where they are missing.