### PR TITLE
Handle program exit consistently

### DIFF
--- a/chap01/unix_list.c
+++ b/chap01/unix_list.c
@@ -34,8 +34,8 @@ int main() {
     struct ifaddrs *addresses;
 
     if (getifaddrs(&addresses) == -1) {
-        printf("getifaddrs call failed\n");
-        return -1;
+        fprintf(stderr, "getifaddrs call failed\n");
+        return 1;
     }
 
     struct ifaddrs *address = addresses;

--- a/chap01/win_init.c
+++ b/chap01/win_init.c
@@ -31,8 +31,8 @@ int main() {
     WSADATA d;
 
     if (WSAStartup(MAKEWORD(2, 2), &d)) {
-        printf("Failed to initialize.\n");
-        return -1;
+        fprintf(stderr, "Failed to initialize.\n");
+        return 1;
     }
 
     WSACleanup();

--- a/chap01/win_list.c
+++ b/chap01/win_list.c
@@ -39,8 +39,8 @@ int main() {
 
     WSADATA d;
     if (WSAStartup(MAKEWORD(2, 2), &d)) {
-        printf("Failed to initialize.\n");
-        return -1;
+        fprintf(stderr, "Failed to initialize.\n");
+        return 1;
     }
 
 
@@ -50,9 +50,9 @@ int main() {
         adapters = (PIP_ADAPTER_ADDRESSES)malloc(asize);
 
         if (!adapters) {
-            printf("Couldn't allocate %ld bytes for adapters.\n", asize);
+            fprintf(stderr, "Couldn't allocate %ld bytes for adapters.\n", asize);
             WSACleanup();
-            return -1;
+            return 1;
         }
 
         int r = GetAdaptersAddresses(AF_UNSPEC, GAA_FLAG_INCLUDE_PREFIX, 0,
@@ -63,10 +63,10 @@ int main() {
         } else if (r == ERROR_SUCCESS) {
             break;
         } else {
-            printf("Error from GetAdaptersAddresses: %d\n", r);
+            fprintf(stderr, "Error from GetAdaptersAddresses: %d\n", r);
             free(adapters);
             WSACleanup();
-            return -1;
+            return 1;
         }
     } while (!adapters);
 

--- a/chap03/tcp_serve_toupper_fork.c
+++ b/chap03/tcp_serve_toupper_fork.c
@@ -97,7 +97,7 @@ int main() {
                 int bytes_received = recv(socket_client, read, 1024, 0);
                 if (bytes_received < 1) {
                     CLOSESOCKET(socket_client);
-                    exit(0);
+                    return 0;
                 }
 
                 int j;

--- a/chap05/dns_query.c
+++ b/chap05/dns_query.c
@@ -229,14 +229,14 @@ void print_dns_message(const char *message, int msg_length) {
 int main(int argc, char *argv[]) {
 
     if (argc < 3) {
-        printf("Usage:\n\tdns_query hostname type\n");
-        printf("Example:\n\tdns_query example.com aaaa\n");
-        exit(0);
+        fprintf(stderr, "Usage:\n\tdns_query hostname type\n");
+        fprintf(stderr, "Example:\n\tdns_query example.com aaaa\n");
+        return 1;
     }
 
     if (strlen(argv[1]) > 253) {
         fprintf(stderr, "Hostname too long.");
-        exit(1);
+        return 1;
     }
 
     unsigned char type;
@@ -253,7 +253,7 @@ int main(int argc, char *argv[]) {
     } else {
         fprintf(stderr, "Unknown type '%s'. Use a, aaaa, txt, mx, or any.",
                 argv[2]);
-        exit(1);
+        return 1;
     }
 
 #if defined(_WIN32)

--- a/chap05/lookup.c
+++ b/chap05/lookup.c
@@ -31,9 +31,9 @@
 int main(int argc, char *argv[]) {
 
     if (argc < 2) {
-        printf("Usage:\n\tlookup hostname\n");
-        printf("Example:\n\tlookup example.com\n");
-        exit(0);
+        fprintf(stderr, "Usage:\n\tlookup hostname\n");
+        fprintf(stderr, "Example:\n\tlookup example.com\n");
+        return 1;
     }
 
 #if defined(_WIN32)

--- a/chap09/https_simple.c
+++ b/chap09/https_simple.c
@@ -61,7 +61,7 @@ int main(int argc, char *argv[]) {
     struct addrinfo *peer_address;
     if (getaddrinfo(hostname, port, &hints, &peer_address)) {
         fprintf(stderr, "getaddrinfo() failed. (%d)\n", GETSOCKETERRNO());
-        exit(1);
+        return 1;
     }
 
     printf("Remote address is: ");
@@ -79,14 +79,14 @@ int main(int argc, char *argv[]) {
             peer_address->ai_socktype, peer_address->ai_protocol);
     if (!ISVALIDSOCKET(server)) {
         fprintf(stderr, "socket() failed. (%d)\n", GETSOCKETERRNO());
-        exit(1);
+        return 1;
     }
 
     printf("Connecting...\n");
     if (connect(server,
                 peer_address->ai_addr, peer_address->ai_addrlen)) {
         fprintf(stderr, "connect() failed. (%d)\n", GETSOCKETERRNO());
-        exit(1);
+        return 1;
     }
     freeaddrinfo(peer_address);
 

--- a/chap09/tls_get_cert.c
+++ b/chap09/tls_get_cert.c
@@ -61,7 +61,7 @@ int main(int argc, char *argv[]) {
     struct addrinfo *peer_address;
     if (getaddrinfo(hostname, port, &hints, &peer_address)) {
         fprintf(stderr, "getaddrinfo() failed. (%d)\n", GETSOCKETERRNO());
-        exit(1);
+        return 1;
     }
 
     printf("Remote address is: ");
@@ -79,14 +79,14 @@ int main(int argc, char *argv[]) {
             peer_address->ai_socktype, peer_address->ai_protocol);
     if (!ISVALIDSOCKET(server)) {
         fprintf(stderr, "socket() failed. (%d)\n", GETSOCKETERRNO());
-        exit(1);
+        return 1;
     }
 
     printf("Connecting...\n");
     if (connect(server,
                 peer_address->ai_addr, peer_address->ai_addrlen)) {
         fprintf(stderr, "connect() failed. (%d)\n", GETSOCKETERRNO());
-        exit(1);
+        return 1;
     }
     freeaddrinfo(peer_address);
 

--- a/chap11/ssh_auth.c
+++ b/chap11/ssh_auth.c
@@ -48,7 +48,7 @@ int main(int argc, char *argv[])
     int ret = ssh_connect(ssh);
     if (ret != SSH_OK) {
         fprintf(stderr, "ssh_connect() failed.\n%s\n", ssh_get_error(ssh));
-        return -1;
+        return 1;
     }
 
     printf("Connected to %s on port %d.\n", hostname, port);
@@ -61,7 +61,7 @@ int main(int argc, char *argv[])
     if (ssh_get_server_publickey(ssh, &key) != SSH_OK) {
         fprintf(stderr, "ssh_get_server_publickey() failed.\n%s\n",
                 ssh_get_error(ssh));
-        return -1;
+        return 1;
     }
 
     unsigned char *hash;
@@ -70,7 +70,7 @@ int main(int argc, char *argv[])
                 &hash, &hash_len) != SSH_OK) {
         fprintf(stderr, "ssh_get_publickey_hash() failed.\n%s\n",
                 ssh_get_error(ssh));
-        return -1;
+        return 1;
     }
 
     printf("Host public key hash:\n");
@@ -125,7 +125,7 @@ int main(int argc, char *argv[])
     {
         fprintf(stderr, "ssh_userauth_password() failed.\n%s\n",
                 ssh_get_error(ssh));
-        return 0;
+        return 1;
     } else {
         printf("Authentication successful!\n");
     }

--- a/chap11/ssh_command.c
+++ b/chap11/ssh_command.c
@@ -48,7 +48,7 @@ int main(int argc, char *argv[])
     int ret = ssh_connect(ssh);
     if (ret != SSH_OK) {
         fprintf(stderr, "ssh_connect() failed.\n%s\n", ssh_get_error(ssh));
-        return -1;
+        return 1;
     }
 
     printf("Connected to %s on port %d.\n", hostname, port);
@@ -61,7 +61,7 @@ int main(int argc, char *argv[])
     if (ssh_get_server_publickey(ssh, &key) != SSH_OK) {
         fprintf(stderr, "ssh_get_server_publickey() failed.\n%s\n",
                 ssh_get_error(ssh));
-        return -1;
+        return 1;
     }
 
     unsigned char *hash;
@@ -70,7 +70,7 @@ int main(int argc, char *argv[])
                 &hash, &hash_len) != SSH_OK) {
         fprintf(stderr, "ssh_get_publickey_hash() failed.\n%s\n",
                 ssh_get_error(ssh));
-        return -1;
+        return 1;
     }
 
     printf("Host public key hash:\n");

--- a/chap11/ssh_connect.c
+++ b/chap11/ssh_connect.c
@@ -51,7 +51,7 @@ int main(int argc, char *argv[])
     int ret = ssh_connect(ssh);
     if (ret != SSH_OK) {
         fprintf(stderr, "ssh_connect() failed.\n%s\n", ssh_get_error(ssh));
-        return -1;
+        return 1;
     }
 
     printf("Connected to %s on port %d.\n", hostname, port);

--- a/chap11/ssh_download.c
+++ b/chap11/ssh_download.c
@@ -48,7 +48,7 @@ int main(int argc, char *argv[])
     int ret = ssh_connect(ssh);
     if (ret != SSH_OK) {
         fprintf(stderr, "ssh_connect() failed.\n%s\n", ssh_get_error(ssh));
-        return -1;
+        return 1;
     }
 
     printf("Connected to %s on port %d.\n", hostname, port);
@@ -61,7 +61,7 @@ int main(int argc, char *argv[])
     if (ssh_get_server_publickey(ssh, &key) != SSH_OK) {
         fprintf(stderr, "ssh_get_server_publickey() failed.\n%s\n",
                 ssh_get_error(ssh));
-        return -1;
+        return 1;
     }
 
     unsigned char *hash;
@@ -70,7 +70,7 @@ int main(int argc, char *argv[])
                 &hash, &hash_len) != SSH_OK) {
         fprintf(stderr, "ssh_get_publickey_hash() failed.\n%s\n",
                 ssh_get_error(ssh));
-        return -1;
+        return 1;
     }
 
     printf("Host public key hash:\n");
@@ -124,7 +124,7 @@ int main(int argc, char *argv[])
     if (ssh_userauth_password(ssh, 0, password) != SSH_AUTH_SUCCESS) {
         fprintf(stderr, "ssh_userauth_password() failed.\n%s\n",
                 ssh_get_error(ssh));
-        return 0;
+        return 1;
     } else {
         printf("Authentication successful!\n");
     }

--- a/chap13/big_send.c
+++ b/chap13/big_send.c
@@ -117,7 +117,7 @@ int main(int argc, char *argv[]) {
             return 1;
         }
         if (r != send_size) {
-            printf("send() only consumed %d bytes.\n", r);
+            fprintf(stderr, "send() only consumed %d bytes.\n", r);
             return 1;
         }
 


### PR DESCRIPTION
Handle error conditions uniformly by following these rules:
- return 0 on success and 1 on failure
- when an error occurs in main() use return
- when an error occurs in a function other than main() use exit()
- error messages are printed on stderr