### PR TITLE
Use separate checks to provide correct error message

### DIFF
--- a/chap10/https_server.c
+++ b/chap10/https_server.c
@@ -292,13 +292,17 @@ int main() {
     }
 
 
-    if (!SSL_CTX_use_certificate_file(ctx, "cert.pem" , SSL_FILETYPE_PEM)
-    || !SSL_CTX_use_PrivateKey_file(ctx, "key.pem", SSL_FILETYPE_PEM)) {
+    if (!SSL_CTX_use_certificate_file(ctx, "cert.pem" , SSL_FILETYPE_PEM)) {
         fprintf(stderr, "SSL_CTX_use_certificate_file() failed.\n");
         ERR_print_errors_fp(stderr);
         return 1;
     }
 
+    if (!SSL_CTX_use_PrivateKey_file(ctx, "key.pem", SSL_FILETYPE_PEM)) {
+        fprintf(stderr, "SSL_CTX_use_PrivateKey_file() failed.\n");
+        ERR_print_errors_fp(stderr);
+        return 1;
+    }
 
     SOCKET server = create_socket(0, "8080");
 

--- a/chap10/tls_time_server.c
+++ b/chap10/tls_time_server.c
@@ -46,13 +46,17 @@ int main() {
     }
 
 
-    if (!SSL_CTX_use_certificate_file(ctx, "cert.pem" , SSL_FILETYPE_PEM)
-    || !SSL_CTX_use_PrivateKey_file(ctx, "key.pem", SSL_FILETYPE_PEM)) {
+    if (!SSL_CTX_use_certificate_file(ctx, "cert.pem" , SSL_FILETYPE_PEM)) {
         fprintf(stderr, "SSL_CTX_use_certificate_file() failed.\n");
         ERR_print_errors_fp(stderr);
         return 1;
     }
 
+    if (!SSL_CTX_use_PrivateKey_file(ctx, "key.pem", SSL_FILETYPE_PEM)) {
+        fprintf(stderr, "SSL_CTX_use_PrivateKey_file() failed.\n");
+        ERR_print_errors_fp(stderr);
+        return 1;
+    }
 
 
     printf("Configuring local address...\n");


### PR DESCRIPTION
Combining the checks for SSL_CTX_use_certificate_file() and SSL_CTX_use_PrivateKey_file() leads to the case where if the second function fails we print a message pointing to the first one, which is misleading. Check the function calls separately.